### PR TITLE
TLS 1.2 support

### DIFF
--- a/Quickstart/00-Starter-Seed/MvcApplication/MvcApplication/Startup.cs
+++ b/Quickstart/00-Starter-Seed/MvcApplication/MvcApplication/Startup.cs
@@ -11,6 +11,9 @@ namespace MvcApplication
     {
         public void Configuration(IAppBuilder app)
         {
+            // Configure TLS 1.2 support
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             // Set Cookies as default authentication type
             app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
             app.UseCookieAuthentication(new CookieAuthenticationOptions

--- a/Quickstart/01-Login/MvcApplication/MvcApplication/Startup.cs
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/Startup.cs
@@ -18,6 +18,9 @@ namespace MvcApplication
     {
         public void Configuration(IAppBuilder app)
         {
+            // Configure TLS 1.2 support
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             // Configure Auth0 parameters
             string auth0Domain = ConfigurationManager.AppSettings["auth0:Domain"];
             string auth0ClientId = ConfigurationManager.AppSettings["auth0:ClientId"];

--- a/Quickstart/02-User-Profile/MvcApplication/MvcApplication/Startup.cs
+++ b/Quickstart/02-User-Profile/MvcApplication/MvcApplication/Startup.cs
@@ -18,6 +18,9 @@ namespace MvcApplication
     {
         public void Configuration(IAppBuilder app)
         {
+            // Configure TLS 1.2 support
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             // Configure Auth0 parameters
             string auth0Domain = ConfigurationManager.AppSettings["auth0:Domain"];
             string auth0ClientId = ConfigurationManager.AppSettings["auth0:ClientId"];

--- a/Quickstart/03-Authorization/MvcApplication/MvcApplication/Startup.cs
+++ b/Quickstart/03-Authorization/MvcApplication/MvcApplication/Startup.cs
@@ -19,6 +19,9 @@ namespace MvcApplication
     {
         public void Configuration(IAppBuilder app)
         {
+            // Configure TLS 1.2 support
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+
             // Configure Auth0 parameters
             string auth0Domain = ConfigurationManager.AppSettings["auth0:Domain"];
             string auth0ClientId = ConfigurationManager.AppSettings["auth0:ClientId"];


### PR DESCRIPTION
Added SecurityProtocol setting on ServicePointManager so that TLS negotiations work correctly on servers requiring non-legacy handshakes.