### PR TITLE
[SDK-1672] Updates Owin.Cookies for SameSite support

### DIFF
--- a/Quickstart/00-Starter-Seed/MvcApplication/MvcApplication/MvcApplication.csproj
+++ b/Quickstart/00-Starter-Seed/MvcApplication/MvcApplication/MvcApplication.csproj
@@ -53,17 +53,17 @@
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Owin, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.4.0.0\lib\net451\Microsoft.Owin.dll</HintPath>
+    <Reference Include="Microsoft.Owin, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.4.0.0\lib\net451\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.4.1.0\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.4.0.0\lib\net451\Microsoft.Owin.Security.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.4.1.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.Cookies, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.Cookies.4.0.0\lib\net451\Microsoft.Owin.Security.Cookies.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security.Cookies, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.Cookies.4.1.0\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
@@ -128,6 +128,8 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
+    <Compile Include="Support\SameSiteCookieManager.cs" />
+    <Compile Include="Support\SameSiteSupport.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Content\bootstrap-theme.css" />

--- a/Quickstart/00-Starter-Seed/MvcApplication/MvcApplication/Startup.cs
+++ b/Quickstart/00-Starter-Seed/MvcApplication/MvcApplication/Startup.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.Owin;
+using Microsoft.Owin.Host.SystemWeb;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
+using MvcApplication.Support;
 using Owin;
 
 [assembly: OwinStartup(typeof(MvcApplication.Startup))]
@@ -16,7 +18,10 @@ namespace MvcApplication
             app.UseCookieAuthentication(new CookieAuthenticationOptions
             {
                 AuthenticationType = CookieAuthenticationDefaults.AuthenticationType,
-                LoginPath = new PathString("/Account/Login")
+                LoginPath = new PathString("/Account/Login"),
+                CookieSameSite = SameSiteMode.Lax,
+                CookieManager = new SameSiteCookieManager(new SystemWebCookieManager()),
+                CookieSecure = CookieSecureOption.SameAsRequest
             });
 
         }

--- a/Quickstart/00-Starter-Seed/MvcApplication/MvcApplication/Support/SameSiteCookieManager.cs
+++ b/Quickstart/00-Starter-Seed/MvcApplication/MvcApplication/Support/SameSiteCookieManager.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Owin;
+using Microsoft.Owin.Infrastructure;
+
+namespace MvcApplication.Support
+{
+    public class SameSiteCookieManager : ICookieManager
+    {
+      private readonly ICookieManager _innerManager;
+
+      public SameSiteCookieManager() : this(new CookieManager())
+      {
+      }
+
+      public SameSiteCookieManager(ICookieManager innerManager)
+      {
+        _innerManager = innerManager;
+      }
+
+      public void AppendResponseCookie(IOwinContext context, string key, string value,
+                                       CookieOptions options)
+      {
+        CheckSameSite(context, options);
+        _innerManager.AppendResponseCookie(context, key, value, options);
+      }
+
+      public void DeleteCookie(IOwinContext context, string key, CookieOptions options)
+      {
+        CheckSameSite(context, options);
+        _innerManager.DeleteCookie(context, key, options);
+      }
+
+      public string GetRequestCookie(IOwinContext context, string key)
+      {
+        return _innerManager.GetRequestCookie(context, key);
+      }
+
+      private void CheckSameSite(IOwinContext context, CookieOptions options)
+      {
+        if (options.SameSite == Microsoft.Owin.SameSiteMode.None &&
+                                SameSite.BrowserDetection.DisallowsSameSiteNone(context.Request.Headers["User-Agent"]))
+        {
+          options.SameSite = null;
+        }
+      }
+    }
+
+}

--- a/Quickstart/00-Starter-Seed/MvcApplication/MvcApplication/Support/SameSiteSupport.cs
+++ b/Quickstart/00-Starter-Seed/MvcApplication/MvcApplication/Support/SameSiteSupport.cs
@@ -1,0 +1,60 @@
+﻿namespace MvcApplication.Support.SameSite
+{
+  public static class BrowserDetection
+  {
+    // Same as https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+    public static bool DisallowsSameSiteNone(string userAgent)
+    {
+      if (string.IsNullOrEmpty(userAgent))
+      {
+        return true;
+      }
+
+      // Note that these detections are a starting point. See https://www.chromium.org/updates/same-site/incompatible-clients for more detections.
+
+      // Cover all iOS based browsers here. This includes:
+      // - Safari on iOS 12 for iPhone, iPod Touch, iPad
+      // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
+      // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
+      // All of which are broken by SameSite=None, because they use the iOS networking stack
+      if (userAgent.Contains("CPU iPhone OS 12") || userAgent.Contains("iPad; CPU OS 12"))
+      {
+        return true;
+      }
+
+      // Cover Mac OS X based browsers that use the Mac OS networking stack. This includes:
+      // - Safari on Mac OS X.
+      // This does not include:
+      // - Chrome on Mac OS X
+      // Because they do not use the Mac OS networking stack.
+      if (userAgent.Contains("Macintosh; Intel Mac OS X 10_14") &&
+          userAgent.Contains("Version/") && userAgent.Contains("Safari"))
+      {
+        return true;
+      }
+
+      // Cover Chrome 50-69, because some versions are broken by SameSite=None,
+      // and none in this range require it.
+      // Note: this covers some pre-Chromium Edge versions,
+      // but pre-Chromium Edge does not require SameSite=None.
+      if (userAgent.Contains("Chrome/5") || userAgent.Contains("Chrome/6"))
+      {
+        return true;
+      }
+
+      // Unreal Engine runs Chromium 59, but does not advertise as Chrome until 4.23. Treat versions of Unreal
+      // that don't specify their Chrome version as lacking support for SameSite=None.
+      if (userAgent.Contains("UnrealEngine") && !userAgent.Contains("Chrome"))
+      {
+        return true;
+      }
+
+      return false;
+    }
+
+    public static bool AllowsSameSiteNone(string userAgent)
+    {
+      return !DisallowsSameSiteNone(userAgent);
+    }
+  }
+}

--- a/Quickstart/00-Starter-Seed/MvcApplication/MvcApplication/packages.config
+++ b/Quickstart/00-Starter-Seed/MvcApplication/MvcApplication/packages.config
@@ -11,10 +11,10 @@
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.0" targetFramework="net47" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.10" targetFramework="net47" />
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net47" developmentDependency="true" />
-  <package id="Microsoft.Owin" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Host.SystemWeb" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Security" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Security.Cookies" version="4.0.0" targetFramework="net47" />
+  <package id="Microsoft.Owin" version="4.1.0" targetFramework="net47" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="4.1.0" targetFramework="net47" />
+  <package id="Microsoft.Owin.Security" version="4.1.0" targetFramework="net47" />
+  <package id="Microsoft.Owin.Security.Cookies" version="4.1.0" targetFramework="net47" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net47" />
   <package id="Modernizr" version="2.8.3" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />

--- a/Quickstart/01-Login/MvcApplication/MvcApplication/MvcApplication.csproj
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/MvcApplication.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MvcApplication</RootNamespace>
     <AssemblyName>MvcApplication</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort>44360</IISExpressSSLPort>
@@ -154,6 +154,8 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
+    <Compile Include="Support\SameSiteCookieManager.cs" />
+    <Compile Include="Support\SameSiteSupport.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Content\bootstrap-theme.css" />

--- a/Quickstart/01-Login/MvcApplication/MvcApplication/MvcApplication.csproj
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/MvcApplication.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props')" />
+  <Import Project="..\packages\Microsoft.Net.Compilers.3.6.0\build\Microsoft.Net.Compilers.props" Condition="Exists('..\packages\Microsoft.Net.Compilers.3.6.0\build\Microsoft.Net.Compilers.props')" />
   <Import Project="..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props" Condition="Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -18,7 +18,7 @@
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
-    <IISExpressSSLPort />
+    <IISExpressSSLPort>44360</IISExpressSSLPort>
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
     <IISExpressUseClassicPipelineMode />
@@ -49,39 +49,39 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
       <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="Kentor.OwinCookieSaver, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Kentor.OwinCookieSaver.1.1.1\lib\net452\Kentor.OwinCookieSaver.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Logging.5.2.2\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=6.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.6.6.0\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.5.2.2\lib\net451\Microsoft.IdentityModel.Protocols.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=6.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.6.6.0\lib\net461\Microsoft.IdentityModel.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.2.2\lib\net451\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.5.3.0\lib\net461\Microsoft.IdentityModel.Protocols.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.2.2\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.3.0\lib\net461\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.4.0.0\lib\net451\Microsoft.Owin.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=6.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.6.6.0\lib\net461\Microsoft.IdentityModel.Tokens.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.4.0.0\lib\net451\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+    <Reference Include="Microsoft.Owin, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.4.0.0\lib\net451\Microsoft.Owin.Security.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.4.1.0\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.Cookies, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.Cookies.4.0.0\lib\net451\Microsoft.Owin.Security.Cookies.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.4.1.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.OpenIdConnect, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.OpenIdConnect.4.0.0\lib\net451\Microsoft.Owin.Security.OpenIdConnect.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security.Cookies, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.Cookies.4.1.0\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.OpenIdConnect, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.OpenIdConnect.4.1.0\lib\net45\Microsoft.Owin.Security.OpenIdConnect.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
@@ -94,10 +94,11 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.2.2\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=6.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.6.6.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web.DynamicData" />
@@ -106,6 +107,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.6\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
@@ -116,7 +118,7 @@
       <HintPath>..\packages\Microsoft.AspNet.Web.Optimization.1.1.3\lib\net40\System.Web.Optimization.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Razor, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.6\lib\net45\System.Web.Razor.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Razor.3.2.7\lib\net45\System.Web.Razor.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Routing" />
     <Reference Include="System.Web.WebPages, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -136,6 +138,7 @@
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">
     </Reference>
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="WebGrease, Version=1.6.5135.21930, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>
     </Reference>
@@ -251,7 +254,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\build\net46\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.2.8.2\build\Microsoft.Net.Compilers.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Net.Compilers.3.6.0\build\Microsoft.Net.Compilers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Net.Compilers.3.6.0\build\Microsoft.Net.Compilers.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Quickstart/01-Login/MvcApplication/MvcApplication/Startup.cs
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/Startup.cs
@@ -5,9 +5,11 @@ using System.Threading.Tasks;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin;
+using Microsoft.Owin.Host.SystemWeb;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
 using Microsoft.Owin.Security.OpenIdConnect;
+using MvcApplication.Support;
 using Owin;
 
 [assembly: OwinStartup(typeof(MvcApplication.Startup))]
@@ -31,7 +33,8 @@ namespace MvcApplication
             {
                 AuthenticationType = CookieAuthenticationDefaults.AuthenticationType,
                 LoginPath = new PathString("/Account/Login"),
-                CookieSameSite = SameSiteMode.None
+                CookieSameSite = SameSiteMode.Lax,
+                CookieManager = new SameSiteCookieManager(new SystemWebCookieManager())
             });
 
             // Configure Auth0 authentication

--- a/Quickstart/01-Login/MvcApplication/MvcApplication/Startup.cs
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/Startup.cs
@@ -25,15 +25,13 @@ namespace MvcApplication
             string auth0RedirectUri = ConfigurationManager.AppSettings["auth0:RedirectUri"];
             string auth0PostLogoutRedirectUri = ConfigurationManager.AppSettings["auth0:PostLogoutRedirectUri"];
 
-            // Enable Kentor Cookie Saver middleware
-            app.UseKentorOwinCookieSaver();
-
             // Set Cookies as default authentication type
             app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
             app.UseCookieAuthentication(new CookieAuthenticationOptions
             {
                 AuthenticationType = CookieAuthenticationDefaults.AuthenticationType,
-                LoginPath = new PathString("/Account/Login")
+                LoginPath = new PathString("/Account/Login"),
+                CookieSameSite = SameSiteMode.None
             });
 
             // Configure Auth0 authentication

--- a/Quickstart/01-Login/MvcApplication/MvcApplication/Support/SameSiteCookieManager.cs
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/Support/SameSiteCookieManager.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Owin;
+using Microsoft.Owin.Infrastructure;
+
+namespace MvcApplication.Support
+{
+    public class SameSiteCookieManager : ICookieManager
+    {
+      private readonly ICookieManager _innerManager;
+
+      public SameSiteCookieManager() : this(new CookieManager())
+      {
+      }
+
+      public SameSiteCookieManager(ICookieManager innerManager)
+      {
+        _innerManager = innerManager;
+      }
+
+      public void AppendResponseCookie(IOwinContext context, string key, string value,
+                                       CookieOptions options)
+      {
+        CheckSameSite(context, options);
+        _innerManager.AppendResponseCookie(context, key, value, options);
+      }
+
+      public void DeleteCookie(IOwinContext context, string key, CookieOptions options)
+      {
+        CheckSameSite(context, options);
+        _innerManager.DeleteCookie(context, key, options);
+      }
+
+      public string GetRequestCookie(IOwinContext context, string key)
+      {
+        return _innerManager.GetRequestCookie(context, key);
+      }
+
+      private void CheckSameSite(IOwinContext context, CookieOptions options)
+      {
+        if (options.SameSite == Microsoft.Owin.SameSiteMode.None &&
+                                SameSite.BrowserDetection.DisallowsSameSiteNone(context.Request.Headers["User-Agent"]))
+        {
+          options.SameSite = null;
+        }
+      }
+    }
+
+}

--- a/Quickstart/01-Login/MvcApplication/MvcApplication/Support/SameSiteSupport.cs
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/Support/SameSiteSupport.cs
@@ -1,0 +1,60 @@
+﻿namespace MvcApplication.Support.SameSite
+{
+  public static class BrowserDetection
+  {
+    // Same as https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+    public static bool DisallowsSameSiteNone(string userAgent)
+    {
+      if (string.IsNullOrEmpty(userAgent))
+      {
+        return true;
+      }
+
+      // Note that these detections are a starting point. See https://www.chromium.org/updates/same-site/incompatible-clients for more detections.
+
+      // Cover all iOS based browsers here. This includes:
+      // - Safari on iOS 12 for iPhone, iPod Touch, iPad
+      // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
+      // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
+      // All of which are broken by SameSite=None, because they use the iOS networking stack
+      if (userAgent.Contains("CPU iPhone OS 12") || userAgent.Contains("iPad; CPU OS 12"))
+      {
+        return true;
+      }
+
+      // Cover Mac OS X based browsers that use the Mac OS networking stack. This includes:
+      // - Safari on Mac OS X.
+      // This does not include:
+      // - Chrome on Mac OS X
+      // Because they do not use the Mac OS networking stack.
+      if (userAgent.Contains("Macintosh; Intel Mac OS X 10_14") &&
+          userAgent.Contains("Version/") && userAgent.Contains("Safari"))
+      {
+        return true;
+      }
+
+      // Cover Chrome 50-69, because some versions are broken by SameSite=None,
+      // and none in this range require it.
+      // Note: this covers some pre-Chromium Edge versions,
+      // but pre-Chromium Edge does not require SameSite=None.
+      if (userAgent.Contains("Chrome/5") || userAgent.Contains("Chrome/6"))
+      {
+        return true;
+      }
+
+      // Unreal Engine runs Chromium 59, but does not advertise as Chrome until 4.23. Treat versions of Unreal
+      // that don't specify their Chrome version as lacking support for SameSite=None.
+      if (userAgent.Contains("UnrealEngine") && !userAgent.Contains("Chrome"))
+      {
+        return true;
+      }
+
+      return false;
+    }
+
+    public static bool AllowsSameSiteNone(string userAgent)
+    {
+      return !DisallowsSameSiteNone(userAgent);
+    }
+  }
+}

--- a/Quickstart/01-Login/MvcApplication/MvcApplication/Web.config
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/Web.config
@@ -47,11 +47,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -63,7 +63,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.6.0.0" newVersion="6.6.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -71,7 +71,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.6.0.0" newVersion="6.6.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -88,6 +88,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
         <bindingRedirect oldVersion="1.0.0.0-5.2.6.0" newVersion="5.2.6.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.6.0.0" newVersion="6.6.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Quickstart/01-Login/MvcApplication/MvcApplication/Web.config
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/Web.config
@@ -24,81 +24,81 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.7" />
-    <httpRuntime targetFramework="4.7" />
+    <compilation debug="true" targetFramework="4.7.2"/>
+    <httpRuntime targetFramework="4.7"/>
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed" />
-        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0" />
+        <assemblyIdentity name="Newtonsoft.Json" culture="neutral" publicKeyToken="30ad4fe6b2a6aeed"/>
+        <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="System.Web.Optimization" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930" />
+        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2" />
+        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+        <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.6.0.0" newVersion="6.6.0.0" />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.6.0.0" newVersion="6.6.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.6.0.0" newVersion="6.6.0.0" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.6.0.0" newVersion="6.6.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.2.2.0" newVersion="5.2.2.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0" />
+        <assemblyIdentity name="System.Web.WebPages" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-3.0.0.0" newVersion="3.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35" />
-        <bindingRedirect oldVersion="1.0.0.0-5.2.6.0" newVersion="5.2.6.0" />
+        <assemblyIdentity name="System.Web.Mvc" publicKeyToken="31bf3856ad364e35"/>
+        <bindingRedirect oldVersion="1.0.0.0-5.2.6.0" newVersion="5.2.6.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.6.0.0" newVersion="6.6.0.0" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Logging" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.6.0.0" newVersion="6.6.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <system.codedom>
     <compilers>
-      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
-      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+      <compiler language="c#;cs;csharp" extension=".cs" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701"/>
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb" type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35" warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+"/>
     </compilers>
   </system.codedom>
 </configuration>

--- a/Quickstart/01-Login/MvcApplication/MvcApplication/packages.config
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/packages.config
@@ -4,28 +4,28 @@
   <package id="bootstrap" version="3.3.7" targetFramework="net47" />
   <package id="jQuery" version="3.3.1" targetFramework="net47" />
   <package id="jQuery.Validation" version="1.17.0" targetFramework="net47" />
-  <package id="Kentor.OwinCookieSaver" version="1.1.1" targetFramework="net47" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.6" targetFramework="net47" />
-  <package id="Microsoft.AspNet.Razor" version="3.2.6" targetFramework="net47" />
+  <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net46" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.6" targetFramework="net47" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.0" targetFramework="net47" />
-  <package id="Microsoft.IdentityModel.Logging" version="5.2.2" targetFramework="net47" />
-  <package id="Microsoft.IdentityModel.Protocols" version="5.2.2" targetFramework="net47" />
-  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.2.2" targetFramework="net47" />
-  <package id="Microsoft.IdentityModel.Tokens" version="5.2.2" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.JsonWebTokens" version="6.6.0" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.Logging" version="6.6.0" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.Protocols" version="5.3.0" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.3.0" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.Tokens" version="6.6.0" targetFramework="net47" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.10" targetFramework="net47" />
-  <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net47" developmentDependency="true" />
-  <package id="Microsoft.Owin" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Host.SystemWeb" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Security" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Security.Cookies" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Security.OpenIdConnect" version="4.0.0" targetFramework="net47" />
+  <package id="Microsoft.Net.Compilers" version="3.6.0" targetFramework="net47" developmentDependency="true" />
+  <package id="Microsoft.Owin" version="4.1.0" targetFramework="net472" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="4.1.0" targetFramework="net47" />
+  <package id="Microsoft.Owin.Security" version="4.1.0" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security.Cookies" version="4.1.0" targetFramework="net472" />
+  <package id="Microsoft.Owin.Security.OpenIdConnect" version="4.1.0" targetFramework="net47" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net47" />
   <package id="Modernizr" version="2.8.3" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
   <package id="Owin" version="1.0" targetFramework="net47" />
   <package id="Respond" version="1.4.2" targetFramework="net47" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="5.2.2" targetFramework="net47" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="6.6.0" targetFramework="net47" />
   <package id="WebGrease" version="1.6.0" targetFramework="net47" />
 </packages>

--- a/Quickstart/02-User-Profile/MvcApplication/MvcApplication/MvcApplication.csproj
+++ b/Quickstart/02-User-Profile/MvcApplication/MvcApplication/MvcApplication.csproj
@@ -15,7 +15,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MvcApplication</RootNamespace>
     <AssemblyName>MvcApplication</AssemblyName>
-    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
@@ -49,48 +49,48 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
       <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="Kentor.OwinCookieSaver, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Kentor.OwinCookieSaver.1.1.1\lib\net452\Kentor.OwinCookieSaver.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.3\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Owin, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Identity.Owin.2.2.1\lib\net45\Microsoft.AspNet.Identity.Owin.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Identity.Owin.2.2.3\lib\net45\Microsoft.AspNet.Identity.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Logging.5.2.2\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.5.3.0\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.5.2.2\lib\net451\Microsoft.IdentityModel.Protocols.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.5.3.0\lib\net461\Microsoft.IdentityModel.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.2.2\lib\net451\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.5.3.0\lib\net461\Microsoft.IdentityModel.Protocols.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.2.2\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.3.0\lib\net461\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.4.0.0\lib\net451\Microsoft.Owin.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.3.0\lib\net461\Microsoft.IdentityModel.Tokens.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.4.0.0\lib\net451\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+    <Reference Include="Microsoft.Owin, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.4.0.0\lib\net451\Microsoft.Owin.Security.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.4.1.0\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.Cookies, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.Cookies.4.0.0\lib\net451\Microsoft.Owin.Security.Cookies.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.4.1.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.OAuth, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.OAuth.4.0.0\lib\net451\Microsoft.Owin.Security.OAuth.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security.Cookies, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.Cookies.4.1.0\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.OpenIdConnect, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.OpenIdConnect.4.0.0\lib\net451\Microsoft.Owin.Security.OpenIdConnect.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security.OAuth, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.OAuth.4.1.0\lib\net45\Microsoft.Owin.Security.OAuth.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.OpenIdConnect, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.OpenIdConnect.4.1.0\lib\net45\Microsoft.Owin.Security.OpenIdConnect.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
@@ -103,10 +103,11 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.2.2\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.3.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web.DynamicData" />
@@ -115,6 +116,7 @@
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Abstractions" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.6\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
@@ -145,6 +147,7 @@
     </Reference>
     <Reference Include="System.Net.Http.WebRequest">
     </Reference>
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="WebGrease, Version=1.6.5135.21930, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\WebGrease.1.6.0\lib\WebGrease.dll</HintPath>
     </Reference>
@@ -159,6 +162,8 @@
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Support\SameSiteCookieManager.cs" />
+    <Compile Include="Support\SameSiteSupport.cs" />
     <Compile Include="Startup.cs" />
     <Compile Include="ViewModels\UserProfileViewModel.cs" />
   </ItemGroup>

--- a/Quickstart/02-User-Profile/MvcApplication/MvcApplication/Startup.cs
+++ b/Quickstart/02-User-Profile/MvcApplication/MvcApplication/Startup.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Configuration;
-using System.Net;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin;
+using Microsoft.Owin.Host.SystemWeb;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
 using Microsoft.Owin.Security.OpenIdConnect;
+using MvcApplication.Support;
 using Owin;
 
 [assembly: OwinStartup(typeof(MvcApplication.Startup))]
@@ -25,15 +26,14 @@ namespace MvcApplication
             string auth0RedirectUri = ConfigurationManager.AppSettings["auth0:RedirectUri"];
             string auth0PostLogoutRedirectUri = ConfigurationManager.AppSettings["auth0:PostLogoutRedirectUri"];
 
-            // Enable Kentor Cookie Saver middleware
-            app.UseKentorOwinCookieSaver();
-
             // Set Cookies as default authentication type
             app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
             app.UseCookieAuthentication(new CookieAuthenticationOptions
             {
                 AuthenticationType = CookieAuthenticationDefaults.AuthenticationType,
-                LoginPath = new PathString("/Account/Login")
+                LoginPath = new PathString("/Account/Login"),
+                CookieSameSite = SameSiteMode.Lax,
+                CookieManager = new SameSiteCookieManager(new SystemWebCookieManager())
             });
 
             // Configure Auth0 authentication

--- a/Quickstart/02-User-Profile/MvcApplication/MvcApplication/Support/SameSiteCookieManager.cs
+++ b/Quickstart/02-User-Profile/MvcApplication/MvcApplication/Support/SameSiteCookieManager.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Owin;
+using Microsoft.Owin.Infrastructure;
+
+namespace MvcApplication.Support
+{
+    public class SameSiteCookieManager : ICookieManager
+    {
+      private readonly ICookieManager _innerManager;
+
+      public SameSiteCookieManager() : this(new CookieManager())
+      {
+      }
+
+      public SameSiteCookieManager(ICookieManager innerManager)
+      {
+        _innerManager = innerManager;
+      }
+
+      public void AppendResponseCookie(IOwinContext context, string key, string value,
+                                       CookieOptions options)
+      {
+        CheckSameSite(context, options);
+        _innerManager.AppendResponseCookie(context, key, value, options);
+      }
+
+      public void DeleteCookie(IOwinContext context, string key, CookieOptions options)
+      {
+        CheckSameSite(context, options);
+        _innerManager.DeleteCookie(context, key, options);
+      }
+
+      public string GetRequestCookie(IOwinContext context, string key)
+      {
+        return _innerManager.GetRequestCookie(context, key);
+      }
+
+      private void CheckSameSite(IOwinContext context, CookieOptions options)
+      {
+        if (options.SameSite == Microsoft.Owin.SameSiteMode.None &&
+                                SameSite.BrowserDetection.DisallowsSameSiteNone(context.Request.Headers["User-Agent"]))
+        {
+          options.SameSite = null;
+        }
+      }
+    }
+
+}

--- a/Quickstart/02-User-Profile/MvcApplication/MvcApplication/Support/SameSiteSupport.cs
+++ b/Quickstart/02-User-Profile/MvcApplication/MvcApplication/Support/SameSiteSupport.cs
@@ -1,0 +1,60 @@
+﻿namespace MvcApplication.Support.SameSite
+{
+  public static class BrowserDetection
+  {
+    // Same as https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+    public static bool DisallowsSameSiteNone(string userAgent)
+    {
+      if (string.IsNullOrEmpty(userAgent))
+      {
+        return true;
+      }
+
+      // Note that these detections are a starting point. See https://www.chromium.org/updates/same-site/incompatible-clients for more detections.
+
+      // Cover all iOS based browsers here. This includes:
+      // - Safari on iOS 12 for iPhone, iPod Touch, iPad
+      // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
+      // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
+      // All of which are broken by SameSite=None, because they use the iOS networking stack
+      if (userAgent.Contains("CPU iPhone OS 12") || userAgent.Contains("iPad; CPU OS 12"))
+      {
+        return true;
+      }
+
+      // Cover Mac OS X based browsers that use the Mac OS networking stack. This includes:
+      // - Safari on Mac OS X.
+      // This does not include:
+      // - Chrome on Mac OS X
+      // Because they do not use the Mac OS networking stack.
+      if (userAgent.Contains("Macintosh; Intel Mac OS X 10_14") &&
+          userAgent.Contains("Version/") && userAgent.Contains("Safari"))
+      {
+        return true;
+      }
+
+      // Cover Chrome 50-69, because some versions are broken by SameSite=None,
+      // and none in this range require it.
+      // Note: this covers some pre-Chromium Edge versions,
+      // but pre-Chromium Edge does not require SameSite=None.
+      if (userAgent.Contains("Chrome/5") || userAgent.Contains("Chrome/6"))
+      {
+        return true;
+      }
+
+      // Unreal Engine runs Chromium 59, but does not advertise as Chrome until 4.23. Treat versions of Unreal
+      // that don't specify their Chrome version as lacking support for SameSite=None.
+      if (userAgent.Contains("UnrealEngine") && !userAgent.Contains("Chrome"))
+      {
+        return true;
+      }
+
+      return false;
+    }
+
+    public static bool AllowsSameSiteNone(string userAgent)
+    {
+      return !DisallowsSameSiteNone(userAgent);
+    }
+  }
+}

--- a/Quickstart/02-User-Profile/MvcApplication/MvcApplication/Web.config
+++ b/Quickstart/02-User-Profile/MvcApplication/MvcApplication/Web.config
@@ -24,7 +24,7 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.7" />
+    <compilation debug="true" targetFramework="4.7.2" />
     <httpRuntime targetFramework="4.7" />
   </system.web>
   <runtime>
@@ -47,19 +47,19 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Quickstart/02-User-Profile/MvcApplication/MvcApplication/packages.config
+++ b/Quickstart/02-User-Profile/MvcApplication/MvcApplication/packages.config
@@ -4,31 +4,31 @@
   <package id="bootstrap" version="3.3.7" targetFramework="net47" />
   <package id="jQuery" version="3.3.1" targetFramework="net47" />
   <package id="jQuery.Validation" version="1.17.0" targetFramework="net47" />
-  <package id="Kentor.OwinCookieSaver" version="1.1.1" targetFramework="net47" />
-  <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net47" />
-  <package id="Microsoft.AspNet.Identity.Owin" version="2.2.1" targetFramework="net47" />
+  <package id="Microsoft.AspNet.Identity.Core" version="2.2.3" targetFramework="net47" />
+  <package id="Microsoft.AspNet.Identity.Owin" version="2.2.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.6" targetFramework="net47" />
   <package id="Microsoft.AspNet.Razor" version="3.2.6" targetFramework="net47" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.6" targetFramework="net47" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.0" targetFramework="net47" />
-  <package id="Microsoft.IdentityModel.Logging" version="5.2.2" targetFramework="net47" />
-  <package id="Microsoft.IdentityModel.Protocols" version="5.2.2" targetFramework="net47" />
-  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.2.2" targetFramework="net47" />
-  <package id="Microsoft.IdentityModel.Tokens" version="5.2.2" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.3.0" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.3.0" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.Protocols" version="5.3.0" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.3.0" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.3.0" targetFramework="net47" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.10" targetFramework="net47" />
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net47" developmentDependency="true" />
-  <package id="Microsoft.Owin" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Host.SystemWeb" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Security" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Security.Cookies" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Security.OAuth" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Security.OpenIdConnect" version="4.0.0" targetFramework="net47" />
+  <package id="Microsoft.Owin" version="4.1.0" targetFramework="net47" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="4.1.0" targetFramework="net47" />
+  <package id="Microsoft.Owin.Security" version="4.1.0" targetFramework="net47" />
+  <package id="Microsoft.Owin.Security.Cookies" version="4.1.0" targetFramework="net47" />
+  <package id="Microsoft.Owin.Security.OAuth" version="4.1.0" targetFramework="net47" />
+  <package id="Microsoft.Owin.Security.OpenIdConnect" version="4.1.0" targetFramework="net47" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net47" />
   <package id="Modernizr" version="2.8.3" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
   <package id="Owin" version="1.0" targetFramework="net47" />
   <package id="Respond" version="1.4.2" targetFramework="net47" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="5.2.2" targetFramework="net47" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.3.0" targetFramework="net47" />
   <package id="WebGrease" version="1.6.0" targetFramework="net47" />
 </packages>

--- a/Quickstart/03-Authorization/MvcApplication/MvcApplication/MvcApplication.csproj
+++ b/Quickstart/03-Authorization/MvcApplication/MvcApplication/MvcApplication.csproj
@@ -49,48 +49,48 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
       <HintPath>..\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="Kentor.OwinCookieSaver, Version=1.1.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Kentor.OwinCookieSaver.1.1.1\lib\net452\Kentor.OwinCookieSaver.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.1\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Identity.Core.2.2.3\lib\net45\Microsoft.AspNet.Identity.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.AspNet.Identity.Owin, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.Identity.Owin.2.2.1\lib\net45\Microsoft.AspNet.Identity.Owin.dll</HintPath>
+      <HintPath>..\packages\Microsoft.AspNet.Identity.Owin.2.2.3\lib\net45\Microsoft.AspNet.Identity.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.2.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Logging.5.2.2\lib\net451\Microsoft.IdentityModel.Logging.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.5.3.0\lib\net461\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.5.2.2\lib\net451\Microsoft.IdentityModel.Protocols.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Logging, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Logging.5.3.0\lib\net461\Microsoft.IdentityModel.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.2.2\lib\net451\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Protocols, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.5.3.0\lib\net461\Microsoft.IdentityModel.Protocols.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.2.2\lib\net451\Microsoft.IdentityModel.Tokens.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Protocols.OpenIdConnect.5.3.0\lib\net461\Microsoft.IdentityModel.Protocols.OpenIdConnect.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.4.0.0\lib\net451\Microsoft.Owin.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Tokens, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Tokens.5.3.0\lib\net461\Microsoft.IdentityModel.Tokens.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.4.0.0\lib\net451\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
+    <Reference Include="Microsoft.Owin, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.4.0.0\lib\net451\Microsoft.Owin.Security.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Host.SystemWeb, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.SystemWeb.4.1.0\lib\net45\Microsoft.Owin.Host.SystemWeb.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.Cookies, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.Cookies.4.0.0\lib\net451\Microsoft.Owin.Security.Cookies.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.4.1.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.OAuth, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.OAuth.4.0.0\lib\net451\Microsoft.Owin.Security.OAuth.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security.Cookies, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.Cookies.4.1.0\lib\net45\Microsoft.Owin.Security.Cookies.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Security.OpenIdConnect, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Security.OpenIdConnect.4.0.0\lib\net451\Microsoft.Owin.Security.OpenIdConnect.dll</HintPath>
+    <Reference Include="Microsoft.Owin.Security.OAuth, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.OAuth.4.1.0\lib\net45\Microsoft.Owin.Security.OAuth.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Security.OpenIdConnect, Version=4.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Security.OpenIdConnect.4.1.0\lib\net45\Microsoft.Owin.Security.OpenIdConnect.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.Infrastructure, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
@@ -105,8 +105,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IdentityModel" />
-    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.2.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.2.2\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    <Reference Include="System.IdentityModel.Tokens.Jwt, Version=5.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.3.0\lib\net461\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web.DynamicData" />
@@ -160,6 +160,8 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
+    <Compile Include="Support\SameSiteCookieManager.cs" />
+    <Compile Include="Support\SameSiteSupport.cs" />
     <Compile Include="ViewModels\UserProfileViewModel.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Quickstart/03-Authorization/MvcApplication/MvcApplication/Startup.cs
+++ b/Quickstart/03-Authorization/MvcApplication/MvcApplication/Startup.cs
@@ -1,14 +1,14 @@
 ﻿using System;
 using System.Configuration;
-using System.Net;
-using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Owin;
+using Microsoft.Owin.Host.SystemWeb;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
 using Microsoft.Owin.Security.OpenIdConnect;
+using MvcApplication.Support;
 using Owin;
 
 [assembly: OwinStartup(typeof(MvcApplication.Startup))]
@@ -26,15 +26,14 @@ namespace MvcApplication
             string auth0RedirectUri = ConfigurationManager.AppSettings["auth0:RedirectUri"];
             string auth0PostLogoutRedirectUri = ConfigurationManager.AppSettings["auth0:PostLogoutRedirectUri"];
 
-            // Enable Kentor Cookie Saver middleware
-            app.UseKentorOwinCookieSaver();
-
             // Set Cookies as default authentication type
             app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
             app.UseCookieAuthentication(new CookieAuthenticationOptions
             {
                 AuthenticationType = CookieAuthenticationDefaults.AuthenticationType,
-                LoginPath = new PathString("/Account/Login")
+                LoginPath = new PathString("/Account/Login"),
+                CookieSameSite = SameSiteMode.Lax,
+                CookieManager = new SameSiteCookieManager(new SystemWebCookieManager())
             });
 
             // Configure Auth0 authentication

--- a/Quickstart/03-Authorization/MvcApplication/MvcApplication/Support/SameSiteCookieManager.cs
+++ b/Quickstart/03-Authorization/MvcApplication/MvcApplication/Support/SameSiteCookieManager.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Owin;
+using Microsoft.Owin.Infrastructure;
+
+namespace MvcApplication.Support
+{
+    public class SameSiteCookieManager : ICookieManager
+    {
+      private readonly ICookieManager _innerManager;
+
+      public SameSiteCookieManager() : this(new CookieManager())
+      {
+      }
+
+      public SameSiteCookieManager(ICookieManager innerManager)
+      {
+        _innerManager = innerManager;
+      }
+
+      public void AppendResponseCookie(IOwinContext context, string key, string value,
+                                       CookieOptions options)
+      {
+        CheckSameSite(context, options);
+        _innerManager.AppendResponseCookie(context, key, value, options);
+      }
+
+      public void DeleteCookie(IOwinContext context, string key, CookieOptions options)
+      {
+        CheckSameSite(context, options);
+        _innerManager.DeleteCookie(context, key, options);
+      }
+
+      public string GetRequestCookie(IOwinContext context, string key)
+      {
+        return _innerManager.GetRequestCookie(context, key);
+      }
+
+      private void CheckSameSite(IOwinContext context, CookieOptions options)
+      {
+        if (options.SameSite == Microsoft.Owin.SameSiteMode.None &&
+                                SameSite.BrowserDetection.DisallowsSameSiteNone(context.Request.Headers["User-Agent"]))
+        {
+          options.SameSite = null;
+        }
+      }
+    }
+
+}

--- a/Quickstart/03-Authorization/MvcApplication/MvcApplication/Support/SameSiteSupport.cs
+++ b/Quickstart/03-Authorization/MvcApplication/MvcApplication/Support/SameSiteSupport.cs
@@ -1,0 +1,60 @@
+﻿namespace MvcApplication.Support.SameSite
+{
+  public static class BrowserDetection
+  {
+    // Same as https://devblogs.microsoft.com/aspnet/upcoming-samesite-cookie-changes-in-asp-net-and-asp-net-core/
+    public static bool DisallowsSameSiteNone(string userAgent)
+    {
+      if (string.IsNullOrEmpty(userAgent))
+      {
+        return true;
+      }
+
+      // Note that these detections are a starting point. See https://www.chromium.org/updates/same-site/incompatible-clients for more detections.
+
+      // Cover all iOS based browsers here. This includes:
+      // - Safari on iOS 12 for iPhone, iPod Touch, iPad
+      // - WkWebview on iOS 12 for iPhone, iPod Touch, iPad
+      // - Chrome on iOS 12 for iPhone, iPod Touch, iPad
+      // All of which are broken by SameSite=None, because they use the iOS networking stack
+      if (userAgent.Contains("CPU iPhone OS 12") || userAgent.Contains("iPad; CPU OS 12"))
+      {
+        return true;
+      }
+
+      // Cover Mac OS X based browsers that use the Mac OS networking stack. This includes:
+      // - Safari on Mac OS X.
+      // This does not include:
+      // - Chrome on Mac OS X
+      // Because they do not use the Mac OS networking stack.
+      if (userAgent.Contains("Macintosh; Intel Mac OS X 10_14") &&
+          userAgent.Contains("Version/") && userAgent.Contains("Safari"))
+      {
+        return true;
+      }
+
+      // Cover Chrome 50-69, because some versions are broken by SameSite=None,
+      // and none in this range require it.
+      // Note: this covers some pre-Chromium Edge versions,
+      // but pre-Chromium Edge does not require SameSite=None.
+      if (userAgent.Contains("Chrome/5") || userAgent.Contains("Chrome/6"))
+      {
+        return true;
+      }
+
+      // Unreal Engine runs Chromium 59, but does not advertise as Chrome until 4.23. Treat versions of Unreal
+      // that don't specify their Chrome version as lacking support for SameSite=None.
+      if (userAgent.Contains("UnrealEngine") && !userAgent.Contains("Chrome"))
+      {
+        return true;
+      }
+
+      return false;
+    }
+
+    public static bool AllowsSameSiteNone(string userAgent)
+    {
+      return !DisallowsSameSiteNone(userAgent);
+    }
+  }
+}

--- a/Quickstart/03-Authorization/MvcApplication/MvcApplication/Web.config
+++ b/Quickstart/03-Authorization/MvcApplication/MvcApplication/Web.config
@@ -47,19 +47,19 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Quickstart/03-Authorization/MvcApplication/MvcApplication/packages.config
+++ b/Quickstart/03-Authorization/MvcApplication/MvcApplication/packages.config
@@ -4,31 +4,31 @@
   <package id="bootstrap" version="3.3.7" targetFramework="net47" />
   <package id="jQuery" version="3.3.1" targetFramework="net47" />
   <package id="jQuery.Validation" version="1.17.0" targetFramework="net47" />
-  <package id="Kentor.OwinCookieSaver" version="1.1.1" targetFramework="net47" />
-  <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net47" />
-  <package id="Microsoft.AspNet.Identity.Owin" version="2.2.1" targetFramework="net47" />
+  <package id="Microsoft.AspNet.Identity.Core" version="2.2.3" targetFramework="net47" />
+  <package id="Microsoft.AspNet.Identity.Owin" version="2.2.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.6" targetFramework="net47" />
   <package id="Microsoft.AspNet.Razor" version="3.2.6" targetFramework="net47" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net47" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.6" targetFramework="net47" />
   <package id="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" version="2.0.0" targetFramework="net47" />
-  <package id="Microsoft.IdentityModel.Logging" version="5.2.2" targetFramework="net47" />
-  <package id="Microsoft.IdentityModel.Protocols" version="5.2.2" targetFramework="net47" />
-  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.2.2" targetFramework="net47" />
-  <package id="Microsoft.IdentityModel.Tokens" version="5.2.2" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.JsonWebTokens" version="5.3.0" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.Logging" version="5.3.0" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.Protocols" version="5.3.0" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.3.0" targetFramework="net47" />
+  <package id="Microsoft.IdentityModel.Tokens" version="5.3.0" targetFramework="net47" />
   <package id="Microsoft.jQuery.Unobtrusive.Validation" version="3.2.10" targetFramework="net47" />
   <package id="Microsoft.Net.Compilers" version="2.8.2" targetFramework="net47" developmentDependency="true" />
-  <package id="Microsoft.Owin" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Host.SystemWeb" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Security" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Security.Cookies" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Security.OAuth" version="4.0.0" targetFramework="net47" />
-  <package id="Microsoft.Owin.Security.OpenIdConnect" version="4.0.0" targetFramework="net47" />
+  <package id="Microsoft.Owin" version="4.1.0" targetFramework="net47" />
+  <package id="Microsoft.Owin.Host.SystemWeb" version="4.1.0" targetFramework="net47" />
+  <package id="Microsoft.Owin.Security" version="4.1.0" targetFramework="net47" />
+  <package id="Microsoft.Owin.Security.Cookies" version="4.1.0" targetFramework="net47" />
+  <package id="Microsoft.Owin.Security.OAuth" version="4.1.0" targetFramework="net47" />
+  <package id="Microsoft.Owin.Security.OpenIdConnect" version="4.1.0" targetFramework="net47" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net47" />
   <package id="Modernizr" version="2.8.3" targetFramework="net47" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net47" />
   <package id="Owin" version="1.0" targetFramework="net47" />
   <package id="Respond" version="1.4.2" targetFramework="net47" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="5.2.2" targetFramework="net47" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="5.3.0" targetFramework="net47" />
   <package id="WebGrease" version="1.6.0" targetFramework="net47" />
 </packages>


### PR DESCRIPTION
This PR upgrades the **01-Login** sample - the other samples will be upgraded in separate PRs.

- Upgrade `Microsoft.Owin.Security.Cookies` to 4.1.0, which will allow them to set the SameSite property when configuring cookie authentication. The sample will set this to `Lax` as it doesn't need anything else, but the customer should consider whether other values are more appropriate for them.
- Upgrade to .Net Framework 4.7.2 to enable SameSite support for `SystemWebCookieManager` ([reasoning](https://docs.microsoft.com/en-us/aspnet/samesite/owin-samesite#api-usage-with-samesite))
- Add supporting cookie manager + samesite files to overcome issues with using System.Web cookies and OWIN cookies together