### PR TITLE
Update startup.cs

### DIFF
--- a/Quickstart/01-Login/MvcApplication/MvcApplication/Startup.cs
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/Startup.cs
@@ -57,7 +57,8 @@ namespace MvcApplication
                 {
                     NameClaimType = "name"
                 },
-
+                
+                // SameSiteCookieManager is not a built in constructor but is a separate class created as part of the demo
                 CookieManager = new SameSiteCookieManager(new SystemWebCookieManager()),
 
                 Notifications = new OpenIdConnectAuthenticationNotifications


### PR DESCRIPTION
This was a suggestion from a customer as it took them a while to figure out that SameSiteCookieManager isn't a built-in construct but is a separate class created as part of the GitHub demo. Might be worth mentioning that in the SDK.