### PR TITLE
Use Implicit with FormPost in ASP.NET OWIN

### DIFF
--- a/Quickstart/00-Starter-Seed/MvcApplication/MvcApplication/Web.config
+++ b/Quickstart/00-Starter-Seed/MvcApplication/MvcApplication/Web.config
@@ -11,8 +11,6 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
     <add key="auth0:Domain" value="{DOMAIN}" />
     <add key="auth0:ClientId" value="{CLIENT_ID}" />
-    <add key="auth0:ClientSecret" value="{CLIENT_SECRET}" />
-    <add key="auth0:Audience" value="{API_IDENTIFIER}" />
     <add key="auth0:RedirectUri" value="http://localhost:3000/callback" />
     <add key="auth0:PostLogoutRedirectUri" value="http://localhost:3000/" />
   </appSettings>
@@ -48,11 +46,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Security.OAuth" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/Quickstart/01-Login/MvcApplication/MvcApplication/Controllers/AccountController.cs
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/Controllers/AccountController.cs
@@ -30,7 +30,6 @@ namespace MvcApplication.Controllers
         {
             var claimsIdentity = User.Identity as ClaimsIdentity;
 
-            ViewBag.AccessToken = claimsIdentity?.FindFirst(c => c.Type == "access_token")?.Value;
             ViewBag.IdToken = claimsIdentity?.FindFirst(c => c.Type == "id_token")?.Value;
 
             return View();

--- a/Quickstart/01-Login/MvcApplication/MvcApplication/Startup.cs
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/Startup.cs
@@ -23,8 +23,6 @@ namespace MvcApplication
             // Configure Auth0 parameters
             string auth0Domain = ConfigurationManager.AppSettings["auth0:Domain"];
             string auth0ClientId = ConfigurationManager.AppSettings["auth0:ClientId"];
-            string auth0ClientSecret = ConfigurationManager.AppSettings["auth0:ClientSecret"];
-            string auth0Audience = ConfigurationManager.AppSettings["auth0:Audience"];
             string auth0RedirectUri = ConfigurationManager.AppSettings["auth0:RedirectUri"];
             string auth0PostLogoutRedirectUri = ConfigurationManager.AppSettings["auth0:PostLogoutRedirectUri"];
 
@@ -48,13 +46,9 @@ namespace MvcApplication
                 Authority = $"https://{auth0Domain}",
 
                 ClientId = auth0ClientId,
-                ClientSecret = auth0ClientSecret,
 
                 RedirectUri = auth0RedirectUri,
                 PostLogoutRedirectUri = auth0PostLogoutRedirectUri,
-
-                ResponseType = OpenIdConnectResponseType.CodeIdTokenToken,
-                Scope = "openid profile",
 
                 TokenValidationParameters = new TokenValidationParameters
                 {
@@ -70,22 +64,12 @@ namespace MvcApplication
                     SecurityTokenValidated = notification =>
                     {
                         notification.AuthenticationTicket.Identity.AddClaim(new Claim("id_token", notification.ProtocolMessage.IdToken));
-                        notification.AuthenticationTicket.Identity.AddClaim(new Claim("access_token", notification.ProtocolMessage.AccessToken));
 
                         return Task.FromResult(0);
                     },
                     RedirectToIdentityProvider = notification =>
                     {
-                        if (notification.ProtocolMessage.RequestType == OpenIdConnectRequestType.Authentication)
-                        {
-                            // The context's ProtocolMessage can be used to pass along additional query parameters
-                            // to Auth0's /authorize endpoint.
-                            // 
-                            // Set the audience query parameter to the API identifier to ensure the returned Access Tokens can be used
-                            // to call protected endpoints on the corresponding API.
-                            notification.ProtocolMessage.SetParameter("audience", auth0Audience);
-                        }
-                        else if (notification.ProtocolMessage.RequestType == OpenIdConnectRequestType.Logout)
+                        if (notification.ProtocolMessage.RequestType == OpenIdConnectRequestType.Logout)
                         {
                             var logoutUri = $"https://{auth0Domain}/v2/logout?client_id={auth0ClientId}";
 

--- a/Quickstart/01-Login/MvcApplication/MvcApplication/Views/Account/Tokens.cshtml
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/Views/Account/Tokens.cshtml
@@ -1,10 +1,9 @@
 ﻿<div class="row">
     <div class="col-md-12">
 
-        <h3>Tokens for the User</h3>
-        <p>Tokens can be extracted from the user's claims. You can use these tokens when calling your APIs</p>
-
-        <p><strong>Access Token:</strong> @ViewBag.AccessToken</p>
+        <h3>ID Token for the User</h3>
+        <p>The ID Token can be extracted from the user's claims.</p>
+        
         <p><strong>ID Token:</strong> @ViewBag.IdToken</p>
     </div>
 </div>

--- a/Quickstart/01-Login/MvcApplication/MvcApplication/Web.config
+++ b/Quickstart/01-Login/MvcApplication/MvcApplication/Web.config
@@ -11,8 +11,6 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
     <add key="auth0:Domain" value="{DOMAIN}" />
     <add key="auth0:ClientId" value="{CLIENT_ID}" />
-    <add key="auth0:ClientSecret" value="{CLIENT_SECRET}" />
-    <add key="auth0:Audience" value="{API_IDENTIFIER}" />
     <add key="auth0:RedirectUri" value="http://localhost:3000/callback" />
     <add key="auth0:PostLogoutRedirectUri" value="http://localhost:3000/" />
   </appSettings>

--- a/Quickstart/02-User-Profile/MvcApplication/MvcApplication/Startup.cs
+++ b/Quickstart/02-User-Profile/MvcApplication/MvcApplication/Startup.cs
@@ -22,7 +22,6 @@ namespace MvcApplication
             // Configure Auth0 parameters
             string auth0Domain = ConfigurationManager.AppSettings["auth0:Domain"];
             string auth0ClientId = ConfigurationManager.AppSettings["auth0:ClientId"];
-            string auth0ClientSecret = ConfigurationManager.AppSettings["auth0:ClientSecret"];
             string auth0RedirectUri = ConfigurationManager.AppSettings["auth0:RedirectUri"];
             string auth0PostLogoutRedirectUri = ConfigurationManager.AppSettings["auth0:PostLogoutRedirectUri"];
 
@@ -46,12 +45,10 @@ namespace MvcApplication
                 Authority = $"https://{auth0Domain}",
 
                 ClientId = auth0ClientId,
-                ClientSecret = auth0ClientSecret,
 
                 RedirectUri = auth0RedirectUri,
                 PostLogoutRedirectUri = auth0PostLogoutRedirectUri,
 
-                ResponseType = OpenIdConnectResponseType.CodeIdToken,
                 Scope = "openid profile email",
 
                 TokenValidationParameters = new TokenValidationParameters

--- a/Quickstart/02-User-Profile/MvcApplication/MvcApplication/Web.config
+++ b/Quickstart/02-User-Profile/MvcApplication/MvcApplication/Web.config
@@ -11,7 +11,6 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
     <add key="auth0:Domain" value="{DOMAIN}" />
     <add key="auth0:ClientId" value="{CLIENT_ID}" />
-    <add key="auth0:ClientSecret" value="{CLIENT_SECRET}" />
     <add key="auth0:RedirectUri" value="http://localhost:3000/callback" />
     <add key="auth0:PostLogoutRedirectUri" value="http://localhost:3000/" />
   </appSettings>

--- a/Quickstart/03-Authorization/MvcApplication/MvcApplication/Startup.cs
+++ b/Quickstart/03-Authorization/MvcApplication/MvcApplication/Startup.cs
@@ -22,7 +22,6 @@ namespace MvcApplication
             // Configure Auth0 parameters
             string auth0Domain = ConfigurationManager.AppSettings["auth0:Domain"];
             string auth0ClientId = ConfigurationManager.AppSettings["auth0:ClientId"];
-            string auth0ClientSecret = ConfigurationManager.AppSettings["auth0:ClientSecret"];
             string auth0RedirectUri = ConfigurationManager.AppSettings["auth0:RedirectUri"];
             string auth0PostLogoutRedirectUri = ConfigurationManager.AppSettings["auth0:PostLogoutRedirectUri"];
 
@@ -46,12 +45,10 @@ namespace MvcApplication
                 Authority = $"https://{auth0Domain}",
 
                 ClientId = auth0ClientId,
-                ClientSecret = auth0ClientSecret,
 
                 RedirectUri = auth0RedirectUri,
                 PostLogoutRedirectUri = auth0PostLogoutRedirectUri,
 
-                ResponseType = OpenIdConnectResponseType.CodeIdToken,
                 Scope = "openid profile email",
 
                 TokenValidationParameters = new TokenValidationParameters

--- a/Quickstart/03-Authorization/MvcApplication/MvcApplication/Web.config
+++ b/Quickstart/03-Authorization/MvcApplication/MvcApplication/Web.config
@@ -11,7 +11,6 @@
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
     <add key="auth0:Domain" value="{DOMAIN}" />
     <add key="auth0:ClientId" value="{CLIENT_ID}" />
-    <add key="auth0:ClientSecret" value="{CLIENT_SECRET}" />
     <add key="auth0:RedirectUri" value="http://localhost:3000/callback" />
     <add key="auth0:PostLogoutRedirectUri" value="http://localhost:3000/" />
   </appSettings>


### PR DESCRIPTION
This updates the QS sample to use Implicit flow with FormPost, which is the same as we use by default in the latest ASP.NET Core MVC QS.

The benefit here is that we don't need to Client Secret, and a setup like this is probably sufficient for a lot of users who do not need an Access Token in their server-side applications.