### PR TITLE
Revert "Bump System.IdentityModel.Tokens.Jwt from 6.5.0 to 6.30.1 in /Samples/custom-login/MvcApplication"

### DIFF
--- a/Samples/custom-login/MvcApplication/MvcApplication/packages.config
+++ b/Samples/custom-login/MvcApplication/MvcApplication/packages.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Antlr" version="3.5.0.2" targetFramework="net47" />
   <package id="Auth0.AuthenticationApi" version="7.20.0" targetFramework="net472" />
@@ -28,7 +28,7 @@
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net472" />
   <package id="Owin" version="1.0" targetFramework="net47" />
   <package id="Respond" version="1.4.2" targetFramework="net47" />
-  <package id="System.IdentityModel.Tokens.Jwt" version="6.30.1" targetFramework="net472" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="6.5.0" targetFramework="net472" />
   <package id="System.IO" version="4.3.0" targetFramework="net47" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net47" />
   <package id="System.Net.Primitives" version="4.3.1" targetFramework="net47" />


### PR DESCRIPTION
Reverts auth0-samples/auth0-aspnet-owin-mvc-samples#466

As Dependabot doesnt work with OWIN applications, updates break the application.